### PR TITLE
transpose for svd?

### DIFF
--- a/R/PCA_MDS_microarray.Rmd
+++ b/R/PCA_MDS_microarray.Rmd
@@ -76,7 +76,7 @@ The other ds are all zeros. (no variations after d(r)), that's why D is dropped 
 
 We can check it:  
 ```{r}
-# we transpose X again for svd
+# we transpose X again for svd ### You don't really have to transpose again for svd, do you ? 
 sv = svd(t(X))
 U = sv$u
 V = sv$v


### PR DESCRIPTION
If you transpose, the first two principal componentes explain 0.3808657 of the total variation in your dataset. 
If you do not transpose, PC1 and PC2 explain 0.3808657 of the total variation. 
